### PR TITLE
feat: 修复popover插槽宽度较小时，弹出层的箭头样式偏移错乱问题，优化clickoutside

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -40,6 +40,8 @@
   - 占位图改用网络地址，小程序打包时会将未使用的组件也打包进去，如果使用本地图片，会明显增大小程序包体积 (by [@yawuling](https://github.com/yawuling) ) )
 - 定位层级
   - 优化多个组件的定位层级 (by [@yawuling](https://github.com/yawuling) ) )
+- clickoutside
+  - 给 `wd-drop-menu`, `wd-popover`, `wd-swipe-action`, `wd-tooltip` 添加 `clickoutside` 功能，优化点击非组件区域时关闭组件的方案 (by [@yawuling](https://github.com/yawuling) ) )
 
 #### Bug 修复
 
@@ -59,8 +61,12 @@
   - 修复 `messageBox` 使用 `type` 无效问题 (by [@yawuling](https://github.com/yawuling) ) )
 - Picker
   - 修复手动设置首选项无效问题 (by [@yawuling](https://github.com/yawuling) ) )
+- Popover
+  - 修复插槽宽度较小时，弹出层的箭头样式偏移错乱问题 (by [@yawuling](https://github.com/yawuling) ) )
 - SelectPicker
   - 修复自定义 `label` 插槽失败的问题 (by [@yawuling](https://github.com/yawuling) ) )
+- Tooltip
+  - 修复插槽宽度较小时，弹出层的箭头样式偏移错乱问题 (by [@yawuling](https://github.com/yawuling) ) )
 - Upload
   - 修复 `disabled` 状态下可以删除图片的问题 (by [@yawuling](https://github.com/yawuling) ) )
   - 修复图片删除图标层级过高问题 (by [@yawuling](https://github.com/yawuling) ) )

--- a/docs/docs/dropMenu.md
+++ b/docs/docs/dropMenu.md
@@ -21,14 +21,24 @@
 
  通过绑定 `bind:change` 事件，获取当前选中项。
 
+因为小程序组件无法监听点击自己以外的地方，为了在点击页面其他地方时，可以自动关闭 dropmenu ，建议引入组件库的 clickoutside 函数（会关闭所有 dropmenu、popover、toast、swipeAction），在页面的根元素上监听点击事件的冒泡。
+
+:::warning
+如果存在用户手动点击 dropmenu 以外某个地方如按钮弹出 dropmenu 的场景，则需要在点击的元素（在这里上按钮）加上 catchtap 阻止事件冒泡到根元素上，避免触发 clickoutside 把要手动打开的 dropmenu 关闭了。
+:::
+
 ```html
-<wd-drop-menu>
-  <wd-drop-menu-item value="{{ value1 }}" options="{{ option1 }}" bind:change="handleChange1" />
-  <wd-drop-menu-item value="{{ value2 }}" options="{{ option2 }}" bind:change="handleChange2" />
-</wd-drop-menu>
+<view catchtap="clickoutside">
+  <wd-drop-menu>
+    <wd-drop-menu-item value="{{ value1 }}" options="{{ option1 }}" bind:change="handleChange1" />
+    <wd-drop-menu-item value="{{ value2 }}" options="{{ option2 }}" bind:change="handleChange2" />
+  </wd-drop-menu>
+</view>
 ```
 
 ```JavaScript
+import clickoutside from '/wot-design/common/clickoutside'
+
 Page({
   data: {
     value1: 0,
@@ -53,7 +63,8 @@ Page({
     this.setData({
       value1: event.detail.value
     })
-  }
+  },
+  clickoutside: clickoutside
 })
 ```
 
@@ -134,87 +145,6 @@ Page({
   <wd-drop-menu-item value="{{ value1 }}" disabled options="{{ option2 }}" bind:change="handleChange1" />
   <wd-drop-menu-item value="{{ value2 }}" options="{{ option1 }}" bind:change="handleChange2" />
 </wd-drop-menu>
-```
-
-### 点击外部关闭
-
-微信小程序的逻辑层运行在JSCore中，因而缺少相关的DOM API和BOM API，无法监听全局点击事件，因此微信小程序的点击外部关闭需要在实际页面中进行手动处理。
-
-大致思路：
-
-- 1. `drop-menu-item`使用`bind:open`捕获下拉菜单的展开动作
-- 2. 给展示的组件 `drop-menu-item` 绑定id，通过this.selectComponent(idSelector)获取到当前展开的节点
-- 3. 可以通过组件内部的  `open()`/`close()` 方法控制弹出下拉菜单的显隐。
-- 4. 在当前页面的最外层添加点击外部关闭事件，查看当前是否有展开的弹框。
-- 5. 通过`pop.data.showWrapper` 与 `pop.data.showPop`，可以获取该id下下拉菜单的展开情况
-
-```html
-<!-- 当前子页面的最外层 -->
-<view catchtap="clickOutside">
-  <wd-drop-menu>
-    <wd-drop-menu-item
-      id="drop-menu1"
-      value="{{ value1 }}"
-      options="{{ option1 }}"
-      bind:change="handleChange1"
-      bind:open="showDropMenu"
-    />
-    <wd-drop-menu-item
-      id="drop-menu2"
-      value="{{ value2 }}"
-      options="{{ option2 }}"
-      bind:change="handleChange2"
-      bind:open="showDropMenu"
-    />
-  </wd-drop-menu>
-</view>
-```
-
-```JavaScript
-Page({
-  data: {
-    value1: 1,
-    value2: 0,
-    option1: [
-      { label: '全部商品', value: 0 },
-      { label: '新款商品', value: 1, tip: '这是补充信息' },
-      { label: '这是比较长的筛选条件这是比较长的筛选条件', value: 2 }
-    ],
-    option2: [
-      { label: '综合', value: 0 },
-      { label: '销量', value: 1 },
-      { label: '上架时间', value: 2 }
-    ]
-  },
-
-  clickOutside () {
-    this.closeOtherDrop()
-  },
-
-  closeOtherDrop () {
-    if (this.drop && this.drop.data.showWrapper && this.drop.data.showPop) {
-      this.drop.close()
-      this.drop = null
-    }
-  },
-  showDropMenu (event) {
-    const id = event.currentTarget.id
-    if (this.drop && (this.drop.id !== id)) {
-      this.closeOtherDrop()
-    }
-    this.drop = this.selectComponent('#' + id)
-  },
-  handleChange1 ({ detail }) {
-    this.setData({
-      value1: detail.value
-    })
-  },
-  handleChange2 ({ detail }) {
-    this.setData({
-      value2: detail.value
-    })
-  }
-})
 ```
 
 ### DropMenu Attributes

--- a/docs/docs/popover.md
+++ b/docs/docs/popover.md
@@ -16,10 +16,18 @@
 
 Popover 的属性与 [Tooltip](/#/components/tooltip) 很类似，因此对于重复属性，请参考 [Tooltip](/#/components/tooltip) 的文档，在此文档中不做详尽解释。
 
+因为小程序组件无法监听点击自己以外的地方，为了在点击页面其他地方时，可以自动关闭 popover ，建议引入组件库的 clickoutside 函数（会关闭所有 dropmenu、popover、toast、swipeAction），在页面的根元素上监听点击事件的冒泡。
+
+:::warning
+如果存在用户手动点击 popover 以外某个地方如按钮弹出 popover 的场景，则需要在点击的元素（在这里上按钮）加上 catchtap 阻止事件冒泡到根元素上，避免触发 clickoutside 把要手动打开的 popover 关闭了。
+:::
+
 ```html
-<wd-popover show="{{show}}" content="这是一段信息。" bind:change="handleChange">
-  <wd-button >点击展示</wd-button>
-</wd-popover>
+<view catchtap="clickoutside">
+  <wd-popover show="{{show}}" content="这是一段信息。" bind:change="handleChange">
+    <wd-button >点击展示</wd-button>
+  </wd-popover>
+</view>
 ```
 
 ```javascript
@@ -30,7 +38,9 @@ Page({
 
   handleChange (event) {
     this.setData({ show: event.detail.show })
-  }
+  },
+
+  clickoutside: clickoutside
 })
 ```
 
@@ -122,94 +132,6 @@ Page({
   width: 150px;
 }
 
-```
-
-### 点击外部关闭
-
-微信小程序的逻辑层运行在JSCore中，因而缺少相关的DOM API和BOM API，无法监听全局点击事件，因此微信小程序的点击外部关闭需要在实际页面中进行手动处理。
-
-大致思路：
-
-- 1. 唤起项使用`catch`绑定展示逻辑，可以手动操作popover组件展示。
-- 2. 给展示的组件 popover 绑定id，通过this.selectComponent(idSelector)获取到当前展开的节点
-- 3. 可以通过组件内部的  `open()`/`close()` 方法控制弹框的显隐。
-- 4. 在当前页面的最外层添加点击外部关闭事件，查看当前是否有展开的弹框。
-- 5. 通过`pop.data.show`或与pop绑定的`show`变量，可以获取该id下pop的展开情况
-
-页面单个popover情况：
-
-```html
-<!-- 当前子页面的最外层 -->
-<view catchtap="clickOutside">
-  <wd-popover id="pop" content="这是一段信息。">
-    <wd-button bind:tap="showPop">点击展示</wd-button>
-  </wd-popover>
-</view>
-```
-
-```JavaScript
-Page({
-  // 点击外部触发的事件
-  clickOutside () {
-    this.closeOtherPop()
-  },
-
-  // 关闭当前页面展开的其他pop
-  closeOtherPop () {
-    if (this.pop && this.pop.data.show) {
-      this.pop.close()
-      this.pop = null
-    }
-  },
-
-  // 展示popover时，根据id保存当前节点
-  showPop () {
-    if (this.pop && (this.pop.id !== 'pop')) {
-      this.closeOtherPop()
-    }
-    this.pop = this.selectComponent('#pop')
-  }
-})
-```
-
-页面多个popover情况：
-
-```html
-<!-- 当前子页面的最外层 -->
-<view catchtap="clickOutside">
-  <wd-popover id="pop1" content="这是一段信息。">
-    <wd-button bind:tap="showPop" data-id="pop1">点击展示</wd-button>
-  </wd-popover>
-  <wd-popover id="pop2" content="这是一段信息。">
-    <wd-button bind:tap="showPop" data-id="pop2">点击展示</wd-button>
-  </wd-popover>
-  <wd-popover id="pop3" content="这是一段信息。">
-    <wd-button bind:tap="showPop" data-id="pop3">点击展示</wd-button>
-  </wd-popover>
-</view>
-```
-
-```JavaScript
-Page({
-  clickOutside () {
-    this.closeOtherPop()
-  },
-
-  closeOtherPop () {
-    if (this.pop && this.pop.data.show) {
-      this.pop.close()
-      this.pop = null
-    }
-  },
-
-  showPop (event) {
-    const id = event.currentTarget.dataset.id
-    if (this.pop && (this.pop.id !== id)) {
-      this.closeOtherPop()
-    }
-    this.pop = this.selectComponent('#' + id)
-  }
-})
 ```
 
 ### Popover Attributes

--- a/docs/docs/swipeAction.md
+++ b/docs/docs/swipeAction.md
@@ -20,23 +20,33 @@
 
 `wd-swipe-action`分为三部分：'自定义左按钮内容'、'自定义内容'、'自定义右按钮内容'。自定义按钮内容需要设置`slot`开启，自定义内容为默认插槽，无需手动开启。
 
+因为小程序组件无法监听点击自己以外的地方，为了在点击页面其他地方时，可以自动关闭 swipeAction ，建议引入组件库的 clickoutside 函数（会关闭所有 dropmenu、popover、toast、swipeAction），在页面的根元素上监听点击事件的冒泡。
+
+:::warning
+如果存在用户手动点击 swipeAction 以外某个地方如按钮滑出 swipeAction 的场景，则需要在点击的元素（在这里上按钮）加上 catchtap 阻止事件冒泡到根元素上，避免触发 clickoutside 把要手动打开的 swipeAction 关闭了。
+:::
+
 ```html
-<wd-swipe-action>
-  <wd-cell title="标题文字" value="内容"/>
-  <view slot="right" class="action">
-    <view class="button" style="background: #C8C7CD;" bindtap="handleAction" data-action="操作1">操作1</view>
-    <view class="button" style="background: #FFB300;" bindtap="handleAction" data-action="操作2">操作2</view>
-    <view class="button" style="background: #E2231A;" bindtap="handleAction" data-action="操作3">操作3</view>
-  </view>
-</wd-swipe-action>
+<view catchtap="clickoutside">
+  <wd-swipe-action>
+    <wd-cell title="标题文字" value="内容"/>
+    <view slot="right" class="action">
+      <view class="button" style="background: #C8C7CD;" bindtap="handleAction" data-action="操作1">操作1</view>
+      <view class="button" style="background: #FFB300;" bindtap="handleAction" data-action="操作2">操作2</view>
+      <view class="button" style="background: #E2231A;" bindtap="handleAction" data-action="操作3">操作3</view>
+    </view>
+  </wd-swipe-action>
+</view>
 ```
 ```javascript
-import Toast from '../../dist/toast/toast'
+import Toast from '/wot-design/toast/toast'
+import clickoutside from '/wot-design/common/clickoutside'
 
 Page({
   handleAction (event) {
     Toast(`点击了${event.target.dataset.action}`)
-  }
+  },
+  clickoutside: clickoutside
 })
 ```
 ```css

--- a/docs/docs/tooltip.md
+++ b/docs/docs/tooltip.md
@@ -28,20 +28,31 @@
 
 如 `placement="left-end"`，则提示信息出现在目标元素的左侧，且提示信息的底部与目标元素的底部对齐。
 
+因为小程序组件无法监听点击自己以外的地方，为了在点击页面其他地方时，可以自动关闭 tooltip ，建议引入组件库的 clickoutside 函数（会关闭所有 dropmenu、popover、toast、swipeAction），在页面的根元素上监听点击事件的冒泡。
+
+:::warning
+如果存在用户手动点击 tooltip 以外某个地方如按钮滑出 tooltip 的场景，则需要在点击的元素（在这里上按钮）加上 catchtap 阻止事件冒泡到根元素上，避免触发 clickoutside 把要手动打开的 tooltip 关闭了。
+:::
+
 ```html
-<wd-tooltip show="{{ show }}" bind:change="handleChange" placement="top" content="top 提示文字">
-  <wd-button>top</wd-button>
-</wd-tooltip>
+<view catchtap="clickoutside">
+  <wd-tooltip show="{{ show }}" bind:change="handleChange" placement="top" content="top 提示文字">
+    <wd-button>top</wd-button>
+  </wd-tooltip>
+</view>
 ```
 
 ```javascript
+import clickoutside from '/wot-design/common/clickoutside'
+
 Page({
   data: {
     show: false
   },
   handleChange (event) {
     this.setData({ show: event.detail.show })
-  }
+  },
+  clickoutside: clickoutside
 })
 ```
 

--- a/example/pages/dropMenu/index.js
+++ b/example/pages/dropMenu/index.js
@@ -1,3 +1,5 @@
+import clickoutside from '../../wot-design/common/clickoutside'
+
 Page({
   data: {
     show: false,
@@ -21,25 +23,7 @@ Page({
       { label: '上架时间', value: 2 }
     ]
   },
-
-  clickOutside () {
-    this.closeOtherDrop()
-  },
-
-  closeOtherDrop () {
-    if (this.drop && this.drop.data.showWrapper && this.drop.data.showPop) {
-      this.drop.close()
-      this.drop = null
-    }
-  },
-
-  showDropMenu (event) {
-    const id = event.currentTarget.id
-    if (this.drop && (this.drop.id !== id)) {
-      this.closeOtherDrop()
-    }
-    this.drop = this.selectComponent('#' + id)
-  },
+  clickOutside: clickoutside,
   handleChange1 ({ detail }) {
     this.setData({
       value1: detail.value
@@ -64,8 +48,6 @@ Page({
     this.setData({
       value5: detail.value
     })
-    const drop = this.selectComponent('#drop-menu5')
-    drop.close()
   },
   handleChange6 ({ detail }) {
     this.setData({
@@ -89,7 +71,7 @@ Page({
   },
   confirm () {
     // 关闭下拉框
-    const drop = this.selectComponent('#drop-menu4')
+    const drop = this.selectComponent('#drop-menu')
     drop.close()
   }
 })

--- a/example/pages/dropMenu/index.jxml
+++ b/example/pages/dropMenu/index.jxml
@@ -26,16 +26,13 @@
   >
     <wd-drop-menu>
       <wd-drop-menu-item
-        id="drop-menu3"
         value="{{ value3 }}"
         options="{{ option1 }}"
         bind:change="handleChange3"
-        bind:open="showDropMenu"
       />
       <wd-drop-menu-item
-        id="drop-menu4"
+        id="drop-menu"
         title="筛选"
-        bind:open="showDropMenu"
       >
         <view>
           <wd-cell
@@ -65,10 +62,8 @@
     <view style="display: flex; background: #fff; text-align: center;">
       <wd-drop-menu style="flex: 1; min-width: 0;">
         <wd-drop-menu-item
-          id="drop-menu5"
           value="{{ value4 }}"
           options="{{ option1 }}"
-          bind:open="showDropMenu"
           bind:change="handleChange4"
         />
       </wd-drop-menu>
@@ -87,18 +82,14 @@
   >
     <wd-drop-menu direction="up">
       <wd-drop-menu-item
-        id="drop-menu6"
         value="{{ value6 }}"
         options="{{ option1 }}"
         bind:change="handleChange6"
-        bind:open="showDropMenu"
       />
       <wd-drop-menu-item
-        id="drop-menu7"
         value="{{ value7 }}"
         options="{{ option2 }}"
         bind:change="handleChange7"
-        bind:open="showDropMenu"
       />
     </wd-drop-menu>
   </demo-block>
@@ -108,18 +99,14 @@
   >
     <wd-drop-menu direction="up">
       <wd-drop-menu-item
-        id="drop-menu8"
         value="{{ value8 }}"
         disabled
         options="{{ option1 }}"
-        bind:open="showDropMenu"
         bind:change="handleChange8"
       />
       <wd-drop-menu-item
-        id="drop-menu9"
         value="{{ value9 }}"
         options="{{ option2 }}"
-        bind:open="showDropMenu"
         bind:change="handleChange9"
       />
     </wd-drop-menu>

--- a/example/pages/swipeAction/index.js
+++ b/example/pages/swipeAction/index.js
@@ -1,4 +1,5 @@
 import Toast from '../../wot-design/toast/toast'
+import clickoutside from '../../wot-design/common/clickoutside'
 
 Page({
   data: {
@@ -22,5 +23,9 @@ Page({
 
   handleAction (event) {
     Toast(`点击了${event.target.dataset.action}`)
-  }
+  },
+
+  clickoutside: clickoutside,
+
+  noop () {}
 })

--- a/example/pages/swipeAction/index.jxml
+++ b/example/pages/swipeAction/index.jxml
@@ -1,72 +1,80 @@
 <wd-toast id="wd-toast"/>
 
-<demo-block transparent title="基本用法">
-  <wd-swipe-action>
-    <wd-cell title="标题文字" value="内容"/>
-    <view slot="right" class="action">
-      <view class="button" style="background: #fa4350;" bindtap="handleAction" data-action="操作1">操作1</view>
-      <view class="button" style="background: #f0883a;" bindtap="handleAction" data-action="操作2">操作2</view>
-      <view class="button" style="background: #4d80f0;" bindtap="handleAction" data-action="操作3">操作3</view>
+<view catchtap="clickoutside">
+  <demo-block transparent title="基本用法">
+    <wd-swipe-action>
+      <wd-cell title="标题文字" value="内容"/>
+      <view slot="right" class="action">
+        <view class="button" style="background: #fa4350;" bindtap="handleAction" data-action="操作1">操作1</view>
+        <view class="button" style="background: #f0883a;" bindtap="handleAction" data-action="操作2">操作2</view>
+        <view class="button" style="background: #4d80f0;" bindtap="handleAction" data-action="操作3">操作3</view>
+      </view>
+    </wd-swipe-action>
+  </demo-block>
+  
+  
+  <demo-block transparent title="左右滑动">
+    <wd-swipe-action>
+      <view slot="left" class="action">
+        <view class="button" style="background: #fa4350;">操作1</view>
+        <view class="button" style="background: #f0883a;">操作2</view>
+        <view class="button" style="background: #4d80f0;">操作3</view>
+      </view>
+      <wd-cell title="标题文字" value="内容"/>
+      <view slot="right" class="action">
+        <view class="button" style="background: #fa4350;">操作4</view>
+        <view class="button" style="background: #f0883a;">操作5</view>
+        <view class="button" style="background: #4d80f0;">操作6</view>
+      </view>
+    </wd-swipe-action>
+  </demo-block>
+  
+  <demo-block transparent title="切换按钮">
+    <wd-swipe-action value="{{value}}" before-close="{{beforeClose}}">
+      <view slot="left" class="action">
+        <view class="button" style="background: #fa4350;">操作1</view>
+        <view class="button" style="background: #f0883a;">操作2</view>
+        <view class="button" style="background: #4d80f0;">操作3</view>
+      </view>
+      <wd-cell title="标题文字" value="内容"/>
+      <view slot="right" class="action">
+        <view class="button" style="background: #fa4350;">操作4</view>
+        <view class="button" style="background: #f0883a;">操作5</view>
+        <view class="button" style="background: #4d80f0;">操作6</view>
+      </view>
+    </wd-swipe-action>
+  </demo-block>
+  <view class="button-group">
+    <view catchtap="noop">
+      <wd-button size="small" data-value='left' bindclick="changeState">打开左边</wd-button>
     </view>
-  </wd-swipe-action>
-</demo-block>
-
-
-<demo-block transparent title="左右滑动">
-  <wd-swipe-action>
-    <view slot="left" class="action">
-      <view class="button" style="background: #fa4350;">操作1</view>
-      <view class="button" style="background: #f0883a;">操作2</view>
-      <view class="button" style="background: #4d80f0;">操作3</view>
+    <view catchtap="noop">
+      <wd-button size="small" data-value='close' bindclick="changeState">关闭所有</wd-button>
     </view>
-    <wd-cell title="标题文字" value="内容"/>
-    <view slot="right" class="action">
-      <view class="button" style="background: #fa4350;">操作4</view>
-      <view class="button" style="background: #f0883a;">操作5</view>
-      <view class="button" style="background: #4d80f0;">操作6</view>
+    <view catchtap="noop">
+      <wd-button size="small" data-value='right' bindclick="changeState">打开右边</wd-button>
     </view>
-  </wd-swipe-action>
-</demo-block>
-
-<demo-block transparent title="切换按钮">
-  <wd-swipe-action value="{{value}}" before-close="{{beforeClose}}">
-    <view slot="left" class="action">
-      <view class="button" style="background: #fa4350;">操作1</view>
-      <view class="button" style="background: #f0883a;">操作2</view>
-      <view class="button" style="background: #4d80f0;">操作3</view>
-    </view>
-    <wd-cell title="标题文字" value="内容"/>
-    <view slot="right" class="action">
-      <view class="button" style="background: #fa4350;">操作4</view>
-      <view class="button" style="background: #f0883a;">操作5</view>
-      <view class="button" style="background: #4d80f0;">操作6</view>
-    </view>
-  </wd-swipe-action>
-</demo-block>
-<view class="button-group">
-  <wd-button size="small" data-value='left' bindclick="changeState">打开左边</wd-button>
-  <wd-button size="small" data-value='close' bindclick="changeState">关闭所有</wd-button>
-  <wd-button size="small" data-value='right' bindclick="changeState">打开右边</wd-button>
+  </view>
+  
+  <demo-block transparent title="点击事件">
+    <wd-swipe-action bind:click="handleClick">
+      <wd-cell title="标题文字" value="内容"/>
+      <view slot="right" class="action">
+        <view class="button" style="background: #fa4350;">操作1</view>
+        <view class="button" style="background: #f0883a;">操作2</view>
+        <view class="button" style="background: #4d80f0;">操作3</view>
+      </view>
+    </wd-swipe-action>
+  </demo-block>
+  
+  <demo-block transparent title="禁用滑动按钮">
+    <wd-swipe-action disabled>
+      <wd-cell title="标题文字" value="内容"/>
+      <view slot="right" class="action">
+        <view class="button" style="background: #fa4350;">操作1</view>
+        <view class="button" style="background: #f0883a;">操作2</view>
+        <view class="button" style="background: #4d80f0;">操作3</view>
+      </view>
+    </wd-swipe-action>
+  </demo-block>
 </view>
-
-<demo-block transparent title="点击事件">
-  <wd-swipe-action bind:click="handleClick">
-    <wd-cell title="标题文字" value="内容"/>
-    <view slot="right" class="action">
-      <view class="button" style="background: #fa4350;">操作1</view>
-      <view class="button" style="background: #f0883a;">操作2</view>
-      <view class="button" style="background: #4d80f0;">操作3</view>
-    </view>
-  </wd-swipe-action>
-</demo-block>
-
-<demo-block transparent title="禁用滑动按钮">
-  <wd-swipe-action disabled>
-    <wd-cell title="标题文字" value="内容"/>
-    <view slot="right" class="action">
-      <view class="button" style="background: #fa4350;">操作1</view>
-      <view class="button" style="background: #f0883a;">操作2</view>
-      <view class="button" style="background: #4d80f0;">操作3</view>
-    </view>
-  </wd-swipe-action>
-</demo-block>

--- a/example/pages/tooltip/index.js
+++ b/example/pages/tooltip/index.js
@@ -1,4 +1,5 @@
 import Toast from '../../wot-design/toast/toast'
+import clickoutside from '../../wot-design/common/clickoutside'
 
 Page({
   data: {
@@ -100,5 +101,10 @@ Page({
 
   handleChange17 (event) {
     this.setData({ show17: event.detail.show })
+  },
+
+  clickoutside (event) {
+    console.log(event)
+    clickoutside()
   }
 })

--- a/example/pages/tooltip/index.json
+++ b/example/pages/tooltip/index.json
@@ -4,6 +4,7 @@
     "demo-block": "../../components/demo-block/index",
     "wd-tooltip": "../../wot-design/tooltip/index",
     "wd-button": "../../wot-design/button/index",
-    "wd-toast": "../../wot-design/toast/index"
+    "wd-toast": "../../wot-design/toast/index",
+    "wd-icon": "../../wot-design/icon/index"
   }
 }

--- a/example/pages/tooltip/index.jxml
+++ b/example/pages/tooltip/index.jxml
@@ -1,186 +1,188 @@
 <wd-toast id="wd-toast" />
-<demo-block title="基本用法">
-  <view class="top">
-    <wd-tooltip
-      show="{{ show1 }}"
-      placement="bottom-start"
-      content="bottom-start 提示文字"
-      bind:change="handleChange1"
-    >
-      <wd-button round="{{false}}">bottom-start</wd-button>
-    </wd-tooltip>
-    <wd-tooltip
-      show="{{ show2 }}"
-      placement="bottom"
-      content="bottom 提示文字"
-      bind:change="handleChange2"
-    >
-      <wd-button round="{{false}}">bottom</wd-button>
-    </wd-tooltip>
-    <wd-tooltip
-      show="{{ show3 }}"
-      placement="bottom-end"
-      content="bottom-end 提示文字"
-      bind:change="handleChange3"
-    >
-      <wd-button round="{{false}}">bottom-end</wd-button>
-    </wd-tooltip>
-  </view>
-  <view class="left">
-    <wd-tooltip
-      show="{{ show4 }}"
-      placement="right-start"
-      content="right-start 提示文字"
-      bind:change="handleChange4"
-    >
-      <wd-button round="{{false}}">right-start</wd-button>
-    </wd-tooltip>
-    <wd-tooltip
-      show="{{ show5 }}"
-      placement="right"
-      content="right 提示文字"
-      style="margin: 20px 0;"
-      bind:change="handleChange5"
-    >
-      <wd-button round="{{false}}">right</wd-button>
-    </wd-tooltip>
-    <wd-tooltip
-      show="{{ show6 }}"
-      placement="right-end"
-      content="right-end 提示文字"
-      bind:change="handleChange6"
-    >
-      <wd-button round="{{false}}">right-end</wd-button>
-    </wd-tooltip>
-  </view>
-  <view class="right">
-    <wd-tooltip
-      show="{{ show7 }}"
-      placement="left-start"
-      content="left-start 提示文字"
-      bind:change="handleChange7"
-    >
-      <wd-button round="{{false}}">left-start</wd-button>
-    </wd-tooltip>
-    <wd-tooltip
-      show="{{ show8 }}"
-      placement="left"
-      content="left 提示文字"
-      style="margin: 20px 0;"
-      bind:change="handleChange8"
-    >
-      <wd-button round="{{false}}">left</wd-button>
-    </wd-tooltip>
-    <wd-tooltip
-      show="{{ show9 }}"
-      placement="left-end"
-      content="left-end 提示文字"
-      bind:change="handleChange9"
-    >
-      <wd-button round="{{false}}">left-end</wd-button>
-    </wd-tooltip>
-  </view>
-  <view class="bottom">
-    <wd-tooltip
-      show="{{ show10 }}"
-      placement="top-start"
-      content="top-start 提示文字"
-      bind:change="handleChange10"
-    >
-      <wd-button round="{{false}}">top-start</wd-button>
-    </wd-tooltip>
-    <wd-tooltip
-      show="{{ show11 }}"
-      placement="top"
-      content="top 提示文字"
-      bind:change="handleChange11"
-    >
-      <wd-button round="{{false}}">top</wd-button>
-    </wd-tooltip>
-    <wd-tooltip
-      show="{{ show12 }}"
-      placement="top-end"
-      content="top-end 提示文字"
-      bind:change="handleChange12"
-    >
-      <wd-button round="{{false}}">top-end</wd-button>
-    </wd-tooltip>
-  </view>
-</demo-block>
-<demo-block title="显示关闭按钮">
-  <view class="demo-left">
-    <wd-tooltip
-      show="{{show13}}"
-      content="显示关闭按钮"
-      placement="right"
-      show-close
-      bind:change="handleChange13"
-    >
-      <wd-button round="{{false}}">显示关闭按钮</wd-button>
-    </wd-tooltip>
-  </view>
-</demo-block>
-<demo-block title="多行文本">
-  <view class="demo-left lines-demo">
-    <wd-tooltip
-      show="{{ show14 }}"
-      placement="right"
-      use-content-slot
-      bind:change="handleChange14"
-    >
-      <wd-button round="{{false}}">多行文本</wd-button>
-      <view
-        slot="content"
-        class="lines-content"
+<view catchtap="clickoutside">
+  <demo-block title="基本用法">
+    <view class="top">
+      <wd-tooltip
+        show="{{ show1 }}"
+        placement="bottom-start"
+        content="bottom-start 提示文字"
+        bind:change="handleChange1"
       >
-        <view>多行文本1</view>
-        <view>多行文本2</view>
-        <view>多行文本3</view>
-      </view>
-    </wd-tooltip>
-  </view>
-</demo-block>
-<demo-block title="控制显隐">
-  <wd-button
-    plain
-    bind:tap="control"
-    size="small"
-    class="button-control"
-  >{{ show15 ? '关闭' : '打开' }}</wd-button>
-  <view class="demo-left demo-control">
-    <wd-tooltip
-      placement="top"
-      content="控制显隐"
-      show="{{ show15 }}"
-    >
-      <wd-button round="{{false}}">top</wd-button>
-    </wd-tooltip>
-  </view>
-</demo-block>
-<demo-block title="绑定事件">
-  <view class="demo-left">
-    <wd-tooltip
-      show="{{ show16 }}"
-      placement="right-end"
-      content="{{ content }}"
-      bind:open="onShow"
-      bind:close="onHide"
-      bind:change="handleChange16"
-    >
-      <wd-button round="{{false}}">事件</wd-button>
-    </wd-tooltip>
-  </view>
-</demo-block>
-<demo-block title="禁用">
-  <view class="demo-left">
-    <wd-tooltip
-      show="{{ show17 }}"
-      placement="right-end"
-      content="禁用"
-      disabled
-      bind:change="handleChange17"
-    >
-      <wd-button round="{{false}}">禁用</wd-button>
-    </wd-tooltip>
-  </view>
-</demo-block>
+        <wd-button round="{{false}}">bottom-start</wd-button>
+      </wd-tooltip>
+      <wd-tooltip
+        show="{{ show2 }}"
+        placement="bottom"
+        content="bottom 提示文字"
+        bind:change="handleChange2"
+      >
+        <wd-button round="{{false}}">bottom</wd-button>
+      </wd-tooltip>
+      <wd-tooltip
+        show="{{ show3 }}"
+        placement="bottom-end"
+        content="bottom-end 提示文字"
+        bind:change="handleChange3"
+      >
+        <wd-button round="{{false}}">bottom-end</wd-button>
+      </wd-tooltip>
+    </view>
+    <view class="left">
+      <wd-tooltip
+        show="{{ show4 }}"
+        placement="right-start"
+        content="right-start 提示文字"
+        bind:change="handleChange4"
+      >
+        <wd-button round="{{false}}">right-start</wd-button>
+      </wd-tooltip>
+      <wd-tooltip
+        show="{{ show5 }}"
+        placement="right"
+        content="right 提示文字"
+        style="margin: 20px 0;"
+        bind:change="handleChange5"
+      >
+        <wd-button round="{{false}}">right</wd-button>
+      </wd-tooltip>
+      <wd-tooltip
+        show="{{ show6 }}"
+        placement="right-end"
+        content="right-end 提示文字"
+        bind:change="handleChange6"
+      >
+        <wd-button round="{{false}}">right-end</wd-button>
+      </wd-tooltip>
+    </view>
+    <view class="right">
+      <wd-tooltip
+        show="{{ show7 }}"
+        placement="left-start"
+        content="left-start 提示文字"
+        bind:change="handleChange7"
+      >
+        <wd-button round="{{false}}">left-start</wd-button>
+      </wd-tooltip>
+      <wd-tooltip
+        show="{{ show8 }}"
+        placement="left"
+        content="left 提示文字"
+        style="margin: 20px 0;"
+        bind:change="handleChange8"
+      >
+        <wd-button round="{{false}}">left</wd-button>
+      </wd-tooltip>
+      <wd-tooltip
+        show="{{ show9 }}"
+        placement="left-end"
+        content="left-end 提示文字"
+        bind:change="handleChange9"
+      >
+        <wd-button round="{{false}}">left-end</wd-button>
+      </wd-tooltip>
+    </view>
+    <view class="bottom">
+      <wd-tooltip
+        show="{{ show10 }}"
+        placement="top-start"
+        content="top-start 提示文字"
+        bind:change="handleChange10"
+      >
+        <wd-button round="{{false}}">top-start</wd-button>
+      </wd-tooltip>
+      <wd-tooltip
+        show="{{ show11 }}"
+        placement="top"
+        content="top 提示文字"
+        bind:change="handleChange11"
+      >
+        <wd-button round="{{false}}">top</wd-button>
+      </wd-tooltip>
+      <wd-tooltip
+        show="{{ show12 }}"
+        placement="top-end"
+        content="top-end 提示文字"
+        bind:change="handleChange12"
+      >
+        <wd-button round="{{false}}">top-end</wd-button>
+      </wd-tooltip>
+    </view>
+  </demo-block>
+  <demo-block title="显示关闭按钮">
+    <view class="demo-left">
+      <wd-tooltip
+        show="{{show13}}"
+        content="显示关闭按钮"
+        placement="right"
+        show-close
+        bind:change="handleChange13"
+      >
+        <wd-button round="{{false}}">显示关闭按钮</wd-button>
+      </wd-tooltip>
+    </view>
+  </demo-block>
+  <demo-block title="多行文本">
+    <view class="demo-left lines-demo">
+      <wd-tooltip
+        show="{{ show14 }}"
+        placement="right"
+        use-content-slot
+        bind:change="handleChange14"
+      >
+        <wd-button round="{{false}}">多行文本</wd-button>
+        <view
+          slot="content"
+          class="lines-content"
+        >
+          <view>多行文本1</view>
+          <view>多行文本2</view>
+          <view>多行文本3</view>
+        </view>
+      </wd-tooltip>
+    </view>
+  </demo-block>
+  <demo-block title="控制显隐">
+    <wd-button
+      plain
+      bind:tap="control"
+      size="small"
+      class="button-control"
+    >{{ show15 ? '关闭' : '打开' }}</wd-button>
+    <view class="demo-left demo-control">
+      <wd-tooltip
+        placement="top"
+        content="控制显隐"
+        show="{{ show15 }}"
+      >
+        <wd-button round="{{false}}">top</wd-button>
+      </wd-tooltip>
+    </view>
+  </demo-block>
+  <demo-block title="绑定事件">
+    <view class="demo-left">
+      <wd-tooltip
+        show="{{ show16 }}"
+        placement="right-end"
+        content="{{ content }}"
+        bind:open="onShow"
+        bind:close="onHide"
+        bind:change="handleChange16"
+      >
+        <wd-button round="{{false}}">事件</wd-button>
+      </wd-tooltip>
+    </view>
+  </demo-block>
+  <demo-block title="禁用">
+    <view class="demo-left">
+      <wd-tooltip
+        show="{{ show17 }}"
+        placement="right-end"
+        content="禁用"
+        disabled
+        bind:change="handleChange17"
+      >
+        <wd-button round="{{false}}">禁用</wd-button>
+      </wd-tooltip>
+    </view>
+  </demo-block>
+</view>

--- a/packages/common/clickoutside.js
+++ b/packages/common/clickoutside.js
@@ -1,0 +1,27 @@
+let queue = []
+let outsideId = 1
+
+export function pushToQueue (comp) {
+  comp.outsideId = ++outsideId
+  queue.push(comp)
+}
+
+export function removeFromQueue (comp) {
+  queue = queue.filter(item => {
+    return item.outsideId !== comp.outsideId
+  })
+}
+
+export function closeOther (comp) {
+  queue.forEach(item => {
+    if (item.outsideId !== comp.outsideId) {
+      item.close()
+    }
+  })
+}
+
+export default function closeOutside () {
+  queue.forEach(item => {
+    item.close()
+  })
+}

--- a/packages/dropMenu/index.js
+++ b/packages/dropMenu/index.js
@@ -1,5 +1,5 @@
 import VueComponent from '../common/component'
-let ARRAY = []
+import { closeOther } from '../common/clickoutside'
 
 VueComponent({
   data: {
@@ -53,10 +53,6 @@ VueComponent({
     const { windowHeight } = jd.getSystemInfoSync()
     this.windowHeight = windowHeight
     this.children = []
-    ARRAY.push(this)
-  },
-  destroyed () {
-    ARRAY = ARRAY.filter(item => item !== this)
   },
   mounted () {
     this.updateTitle()
@@ -69,12 +65,7 @@ VueComponent({
       const child = this.children[index]
       // 点击当前 menu, 关闭其他 menu
       if (!child.data.disabled) {
-        ARRAY.forEach(item => {
-          if (item && item !== this) {
-            // 如果点击的不是当前 menu 关闭其他的 menu
-            item.fold(-1)
-          }
-        })
+        closeOther(child)
         this.fold(index)
       }
     },

--- a/packages/dropMenuItem/index.js
+++ b/packages/dropMenuItem/index.js
@@ -1,5 +1,6 @@
 import VueComponent from '../common/component'
 import { debounce } from '../common/util'
+import { pushToQueue, removeFromQueue } from '../common/clickoutside'
 
 VueComponent({
   externalClasses: ['custom-title', 'custom-icon'],
@@ -72,7 +73,11 @@ VueComponent({
     }
   },
   beforeCreate () {
+    pushToQueue(this)
     this.updateTitle = debounce(this.updateTitle, 50)
+  },
+  destroyed () {
+    removeFromQueue(this)
   },
   mounted () {
     this.setDisplayTitle()

--- a/packages/mixins/popover.js
+++ b/packages/mixins/popover.js
@@ -1,3 +1,5 @@
+import { pushToQueue, removeFromQueue, closeOther } from '../common/clickoutside'
+
 /**
  * @description 注意点：
  * 1. 需要控制的位置： 12个
@@ -68,7 +70,10 @@ export default function () {
       show: {
         type: Boolean,
         observer (newValue, oldValue) {
-          newValue && this.control()
+          if (newValue) {
+            this.control()
+            closeOther(this)
+          }
           this.setData({ showStyle: newValue ? 'display: inline-block;' : 'display: none;' })
           this.$emit('change', { show: newValue })
           this.$emit(`${newValue ? 'open' : 'close'}`)
@@ -80,8 +85,16 @@ export default function () {
       this.init()
     },
 
+    beforeCreate () {
+      pushToQueue(this)
+    },
+
     created () {
       this.setData({ showStyle: this.data.show ? 'opacity: 1;' : 'opacity: 0;' })
+    },
+
+    destroyed () {
+      removeFromQueue(this)
     },
 
     methods: {
@@ -145,6 +158,10 @@ export default function () {
         const horizontalX = this.width + arrowSize + offset
         // 左右位（横轴）对应的距离底部的距离
         const horizontalY = this.height / 2
+
+        const offsetX = verticalX - 17 > 0 ? 0 : verticalX - 17
+        const offsetY = horizontalY - 17 > 0 ? 0 : horizontalY - 17
+
         const placements = new Map([
           // 上
           ['top', [
@@ -152,12 +169,12 @@ export default function () {
             'left: 50%;'
           ]],
           ['top-start', [
-            `left:${0}; bottom: ${verticalY}px;`,
-            `left: ${this.popWidth >= this.width ? this.width / 2 : this.popWidth - 25}px;`
+            `left: ${offsetX}px; bottom: ${verticalY}px;`,
+            `left: ${(this.popWidth >= this.width ? this.width / 2 : this.popWidth - 25) - offsetX}px;`
           ]],
           ['top-end', [
-            `right: ${0}; bottom: ${verticalY}px;`,
-            `right: ${this.popWidth >= this.width ? this.width / 2 : this.popWidth - 25}px; transform: translateX(50%);`
+            `right: ${offsetX}px; bottom: ${verticalY}px;`,
+            `right: ${(this.popWidth >= this.width ? this.width / 2 : this.popWidth - 25) - offsetX}px; transform: translateX(50%);`
           ]],
           // 下
           ['bottom', [
@@ -165,12 +182,12 @@ export default function () {
             'left: 50%;'
           ]],
           ['bottom-start', [
-            `left:${0}; top: ${verticalY}px;`,
-            `left: ${this.popWidth >= this.width ? this.width / 2 : this.popWidth - 25}px;`
+            `left: ${offsetX}px; top: ${verticalY}px;`,
+            `left: ${(this.popWidth >= this.width ? this.width / 2 : this.popWidth - 25) - offsetX}px;`
           ]],
           ['bottom-end', [
-            `right: ${0}; top: ${verticalY}px;`,
-            `right: ${this.popWidth >= this.width ? this.width / 2 : this.popWidth - 25}px; transform: translateX(50%);`
+            `right: ${offsetX}px; top: ${verticalY}px;`,
+            `right: ${(this.popWidth >= this.width ? this.width / 2 : this.popWidth - 25) - offsetX}px; transform: translateX(50%);`
           ]],
           // 左
           ['left', [
@@ -178,12 +195,12 @@ export default function () {
             'top: 50%'
           ]],
           ['left-start', [
-            `right: ${horizontalX}px; top: ${0};`,
-            `top: ${this.popHeight >= this.height ? this.height / 2 : this.popHeight - 20}px;`
+            `right: ${horizontalX}px; top: ${offsetY}px;`,
+            `top: ${(this.popHeight >= this.height ? this.height / 2 : this.popHeight - 20) - offsetY}px;`
           ]],
           ['left-end', [
-            `right: ${horizontalX}px; bottom: ${3}px;`,
-            `bottom: ${this.popHeight >= this.height ? this.height / 2 : this.popHeight - 20}px; transform: translateY(50%);`
+            `right: ${horizontalX}px; bottom: ${offsetY}px;`,
+            `bottom: ${(this.popHeight >= this.height ? this.height / 2 : this.popHeight - 20) - offsetY}px; transform: translateY(50%);`
           ]],
           // 右
           ['right', [
@@ -191,12 +208,12 @@ export default function () {
             'top: 50%'
           ]],
           ['right-start', [
-            `left: ${horizontalX}px; top: ${0};`,
-            `top: ${this.popHeight >= this.height ? this.height / 2 : this.popHeight - 20}px;`
+            `left: ${horizontalX}px; top: ${offsetY}px;`,
+            `top: ${(this.popHeight >= this.height ? this.height / 2 : this.popHeight - 20) - offsetY}px;`
           ]],
           ['right-end', [
-            `left: ${horizontalX}px; bottom: ${3}px;`,
-            `bottom: ${this.popHeight >= this.height ? this.height / 2 : this.popHeight - 20}px; transform: translateY(50%);`
+            `left: ${horizontalX}px; bottom: ${offsetY}px;`,
+            `bottom: ${(this.popHeight >= this.height ? this.height / 2 : this.popHeight - 20) - offsetY}px; transform: translateY(50%);`
           ]]
         ])
 

--- a/packages/swipeAction/index.js
+++ b/packages/swipeAction/index.js
@@ -1,5 +1,6 @@
 import VueComponent from '../common/component'
 import touch from '../mixins/touch'
+import { pushToQueue, removeFromQueue, closeOther } from '../common/clickoutside'
 
 VueComponent({
   mixins: [touch()],
@@ -110,6 +111,7 @@ VueComponent({
 
       this.originOffset = this.wrapperOffset
       this.touchStart(event)
+      closeOther(this)
     },
     /**
      * @description 滑动时，逐渐展示按钮
@@ -225,6 +227,7 @@ VueComponent({
     }
   },
   beforeCreate () {
+    pushToQueue(this)
     // 滑动开始时，wrapper的偏移量
     this.originOffset = 0
     // wrapper现在的偏移量
@@ -240,5 +243,8 @@ VueComponent({
     this.touching = true
     this.changeState(this.data.value)
     this.touching = false
+  },
+  destroyed () {
+    removeFromQueue(this)
   }
 })


### PR DESCRIPTION
#### 优化

- clickoutside
  - 给 `wd-drop-menu`, `wd-popover`, `wd-swipe-action`, `wd-tooltip` 添加 `clickoutside` 功能，优化点击非组件区域时关闭组件的方案

#### Bug 修复

- Popover
  - 修复插槽宽度较小时，弹出层的箭头样式偏移错乱问题
- Tooltip
  - 修复插槽宽度较小时，弹出层的箭头样式偏移错乱问题